### PR TITLE
Add route check after login

### DIFF
--- a/src/app/pages/login/login.component.ts
+++ b/src/app/pages/login/login.component.ts
@@ -1,6 +1,7 @@
 import { Component } from '@angular/core';
 import { FormBuilder, FormGroup, Validators, ReactiveFormsModule } from '@angular/forms';
 import { Router } from '@angular/router';
+import { RutasService } from '../../services/rutas.service';
 import { CommonModule } from '@angular/common';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
@@ -25,7 +26,7 @@ export class LoginComponent {
   form: FormGroup;
   errorMessage: string = '';
 
-  constructor(private fb: FormBuilder, private router: Router) {
+  constructor(private fb: FormBuilder, private router: Router, private rutasService: RutasService) {
     this.form = this.fb.group({
       username: ['', Validators.required],
       password: ['', Validators.required]
@@ -35,9 +36,19 @@ export class LoginComponent {
   login() {
     const { username, password } = this.form.value;
     if (username === 'admin' && password === 'soyscout') {
-       const routeId = '1234'; // esto puede cambiar luego según el usuario
-       this.router.navigate(['/rutas']);
-       //this.router.navigate(['/navegar', routeId]);
+      this.rutasService.obtenerRutas().subscribe({
+        next: rutas => {
+          if (rutas.length === 0) {
+            this.router.navigate(['/crear']);
+          } else {
+            this.router.navigate(['/rutas']);
+          }
+        },
+        error: err => {
+          console.error('Error al obtener rutas', err);
+          this.errorMessage = 'Error al obtener rutas';
+        }
+      });
     } else {
       this.errorMessage = 'Usuario o contraseña incorrectos';
     }


### PR DESCRIPTION
## Summary
- inject `RutasService` in `LoginComponent`
- after verifying credentials, load routes and navigate depending on the result

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68407d2a07a08325b901fdfb3a2a4c7b