### PR TITLE
Add production env configuration

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -46,6 +46,12 @@
           },
           "configurations": {
             "production": {
+              "fileReplacements": [
+                {
+                  "replace": "src/environments/environment.ts",
+                  "with": "src/environments/environment.prod.ts"
+                }
+              ],
               "optimization": true,
               "outputHashing": "all",
               "sourceMap": false,

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,0 +1,12 @@
+export const environment = {
+    production: true,
+    firebaseConfig: {
+        apiKey: "AIzaSyCOb86cUTNn_27hHjCExRK3e7ujUY4lCic",
+        authDomain: "scout-rutas.firebaseapp.com",
+        projectId: "scout-rutas",
+        storageBucket: "scout-rutas.firebasestorage.app",
+        messagingSenderId: "148215706602",
+        appId: "1:148215706602:web:f97454cc0f856b27e67893",
+        measurementId: "G-MCMV57V0QN"
+    }
+};


### PR DESCRIPTION
## Summary
- add a dedicated `environment.prod.ts` file with `production: true`
- replace `environment.ts` with the production file for production builds

## Testing
- `npm test --silent` *(fails: `ng` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68408866575483259a83e72bad7615f0