### PR TITLE
Implement Firestore persistence for routes

### DIFF
--- a/src/app/pages/crear-ruta/crear-ruta.component.spec.ts
+++ b/src/app/pages/crear-ruta/crear-ruta.component.spec.ts
@@ -1,6 +1,8 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { CrearRutaComponent } from './crear-ruta.component';
+import { RutasService } from '../../services/rutas.service';
+import { of } from 'rxjs';
 
 describe('CrearRutaComponent', () => {
   let component: CrearRutaComponent;
@@ -8,7 +10,10 @@ describe('CrearRutaComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [CrearRutaComponent]
+      imports: [CrearRutaComponent],
+      providers: [
+        { provide: RutasService, useValue: { agregarRuta: () => Promise.resolve() } }
+      ]
     })
     .compileComponents();
 

--- a/src/app/pages/crear-ruta/crear-ruta.component.ts
+++ b/src/app/pages/crear-ruta/crear-ruta.component.ts
@@ -16,6 +16,8 @@ import { MatInputModule } from '@angular/material/input';
 import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
+import { RutasService } from '../../services/rutas.service';
+import { Ruta } from '../../models/ruta';
 
 @Component({
   standalone: true,
@@ -38,7 +40,11 @@ export class CrearRutaComponent {
     return this.form.get('equipos') as FormArray<FormControl<string>>;
   }
 
-  constructor(private fb: FormBuilder, private router: Router) {
+  constructor(
+    private fb: FormBuilder,
+    private router: Router,
+    private rutasService: RutasService
+  ) {
     this.form = this.fb.group({
       nombre: ['', Validators.required],
       fechaInicio: ['', Validators.required],
@@ -62,7 +68,12 @@ export class CrearRutaComponent {
     if (this.form.valid) {
       const datosRuta = this.form.value;
       localStorage.setItem('rutaTemporal', JSON.stringify(datosRuta));
-      this.router.navigate(['/mapa']);
+      this.rutasService.agregarRuta({
+        ...datosRuta,
+        puntos: []
+      } as Ruta).then(() => {
+        this.router.navigate(['/mapa']);
+      });
     }
   }
 }

--- a/src/app/pages/mapa/mapa.component.spec.ts
+++ b/src/app/pages/mapa/mapa.component.spec.ts
@@ -1,6 +1,8 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { MapaComponent } from './mapa.component';
+import { RutasService } from '../../services/rutas.service';
+import { of } from 'rxjs';
 
 describe('MapaComponent', () => {
   let component: MapaComponent;
@@ -8,7 +10,10 @@ describe('MapaComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [MapaComponent]
+      imports: [MapaComponent],
+      providers: [
+        { provide: RutasService, useValue: { agregarRuta: () => Promise.resolve() } }
+      ]
     })
     .compileComponents();
 

--- a/src/app/pages/mapa/mapa.component.ts
+++ b/src/app/pages/mapa/mapa.component.ts
@@ -7,6 +7,7 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
+import { RutasService } from '../../services/rutas.service';
 
 @Component({
   selector: 'app-mapa',
@@ -37,7 +38,7 @@ export class MapaComponent implements OnInit {
   polylinePath: google.maps.LatLngLiteral[] = [];
 
 
-  constructor(private router: Router) {}
+  constructor(private router: Router, private rutasService: RutasService) {}
 
   ngOnInit(): void {
     const datosRuta = localStorage.getItem('rutaTemporal');
@@ -95,8 +96,10 @@ export class MapaComponent implements OnInit {
       distanciaTotal: this.distanciaTotal
     };
     localStorage.setItem('rutaFinal', JSON.stringify(rutaGuardada));
-    alert('Ruta guardada correctamente.');
-    this.router.navigate(['/rutas']);
+    this.rutasService.agregarRuta(rutaGuardada).then(() => {
+      alert('Ruta guardada correctamente.');
+      this.router.navigate(['/rutas']);
+    }).catch(err => console.error('Error al guardar ruta', err));
   }
 
   private calcularDistanciaTotal(): void {

--- a/src/app/pages/navegar-ruta/navegar-ruta.component.spec.ts
+++ b/src/app/pages/navegar-ruta/navegar-ruta.component.spec.ts
@@ -1,6 +1,8 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { NavegarRutaComponent } from './navegar-ruta.component';
+import { RutasService } from '../../services/rutas.service';
+import { of } from 'rxjs';
 
 describe('NavegarRutaComponent', () => {
   let component: NavegarRutaComponent;
@@ -8,7 +10,10 @@ describe('NavegarRutaComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [NavegarRutaComponent]
+      imports: [NavegarRutaComponent],
+      providers: [
+        { provide: RutasService, useValue: { obtenerRutaPorId: () => of(null) } }
+      ]
     })
     .compileComponents();
 

--- a/src/app/pages/navegar-ruta/navegar-ruta.component.ts
+++ b/src/app/pages/navegar-ruta/navegar-ruta.component.ts
@@ -2,6 +2,7 @@ import { Component } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { CommonModule } from '@angular/common';
 import { GoogleMapsModule } from '@angular/google-maps';
+import { RutasService } from '../../services/rutas.service';
 
 interface PuntoRuta {
   nombre: string;
@@ -22,10 +23,22 @@ export class NavegarRutaComponent {
   zoom = 15;
   idRuta: string = '';
 
-  constructor(private route: ActivatedRoute) {
-     this.route.paramMap.subscribe(params => {
+  constructor(private route: ActivatedRoute, private rutasService: RutasService) {
+    this.route.paramMap.subscribe(params => {
       this.idRuta = params.get('id') || '';
-      console.log('ID recibido:', this.idRuta);
+      if (this.idRuta) {
+        this.rutasService.obtenerRutaPorId(this.idRuta).subscribe(ruta => {
+          if (ruta?.puntos) {
+            this.puntos = ruta.puntos as PuntoRuta[];
+            if (this.puntos.length) {
+              this.mapaCentro = {
+                lat: this.puntos[0].lat,
+                lng: this.puntos[0].lng
+              };
+            }
+          }
+        });
+      }
     });
 
     // const id = this.route.snapshot.paramMap.get('id');

--- a/src/app/services/rutas.service.ts
+++ b/src/app/services/rutas.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { collection, collectionData, doc, setDoc, Firestore } from '@angular/fire/firestore';
+import { collection, collectionData, doc, setDoc, docData, Firestore } from '@angular/fire/firestore';
 import { addDoc } from '@angular/fire/firestore';
 import { Observable } from 'rxjs';
 import { Ruta } from '../models/ruta';
@@ -17,6 +17,11 @@ export class RutasService {
 
   obtenerRutas(): Observable<Ruta[]> {
     return collectionData(this.rutasRef, { idField: 'id' }) as Observable<Ruta[]>;
+  }
+
+  obtenerRutaPorId(id: string): Observable<Ruta | undefined> {
+    const rutaRef = doc(this.firestore, `rutas/${id}`);
+    return docData(rutaRef, { idField: 'id' }) as Observable<Ruta | undefined>;
   }
 
   agregarRuta(ruta: Ruta): Promise<void> {


### PR DESCRIPTION
## Summary
- add `obtenerRutaPorId` in `RutasService`
- persist route data from `CrearRutaComponent` when continuing
- save final route through service in `MapaComponent`
- load route from Firestore in `NavegarRutaComponent`
- update unit tests with service stubs

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840887d3860832583001056c3750f0a