### PR TITLE
Handle rutas subscriptions cleanup

### DIFF
--- a/src/app/pages/lista-rutas/lista-rutas.component.ts
+++ b/src/app/pages/lista-rutas/lista-rutas.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, ViewChild } from '@angular/core';
+import { Component, OnInit, OnDestroy, ViewChild } from '@angular/core';
 import { Router } from '@angular/router';
 import { CommonModule } from '@angular/common';
 import { MatListModule } from '@angular/material/list';
@@ -9,6 +9,7 @@ import { QRCodeComponent } from 'angularx-qrcode';
 import { RutasService } from '../../services/rutas.service';
 import { Ruta as RutaBase } from '../../models/ruta';
 import QRCode from 'qrcode';
+import { Subscription } from 'rxjs';
 
 interface Ruta extends RutaBase {
   mostrarQR: boolean;
@@ -29,12 +30,13 @@ interface Ruta extends RutaBase {
   templateUrl: './lista-rutas.component.html',
   styleUrls: ['./lista-rutas.component.scss']
 })
-export class ListaRutasComponent implements OnInit {
+export class ListaRutasComponent implements OnInit, OnDestroy {
   rutas: Ruta[] = [];
   rutaMostrada: Ruta | null = null;
   rutaCompartida: Ruta | null = null;
   qrUrl: string = '';
   @ViewChild('miniMapa') miniMapa?: GoogleMap;
+  private rutasSub?: Subscription;
 
   constructor(
     private router: Router,
@@ -42,7 +44,7 @@ export class ListaRutasComponent implements OnInit {
   ) {}
 
   ngOnInit(): void {
-    this.rutasService.obtenerRutas().subscribe({
+    this.rutasSub = this.rutasService.obtenerRutas().subscribe({
       next: (rutas) => {
         this.rutas = rutas.map(r => ({ ...r, mostrarQR: false, mostrarDetalle: false }));
       },
@@ -50,6 +52,10 @@ export class ListaRutasComponent implements OnInit {
         console.error('Error al obtener rutas:', err);
       }
     });
+  }
+
+  ngOnDestroy(): void {
+    this.rutasSub?.unsubscribe();
   }
 
   navegarRuta(id: string): void {

--- a/src/app/pages/login/login.component.ts
+++ b/src/app/pages/login/login.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, OnDestroy } from '@angular/core';
 import { FormBuilder, FormGroup, Validators, ReactiveFormsModule } from '@angular/forms';
 import { Router } from '@angular/router';
 import { RutasService } from '../../services/rutas.service';
@@ -7,6 +7,7 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatButtonModule } from '@angular/material/button';
 import { MatError } from '@angular/material/form-field';
+import { Subscription } from 'rxjs';
 
 @Component({
   standalone: true,
@@ -22,9 +23,10 @@ import { MatError } from '@angular/material/form-field';
   templateUrl: './login.component.html',
   styleUrls: ['./login.component.scss']
 })
-export class LoginComponent {
+export class LoginComponent implements OnDestroy {
   form: FormGroup;
   errorMessage: string = '';
+  private rutasSub?: Subscription;
 
   constructor(private fb: FormBuilder, private router: Router, private rutasService: RutasService) {
     this.form = this.fb.group({
@@ -36,7 +38,8 @@ export class LoginComponent {
   login() {
     const { username, password } = this.form.value;
     if (username === 'admin' && password === 'soyscout') {
-      this.rutasService.obtenerRutas().subscribe({
+      this.rutasSub?.unsubscribe();
+      this.rutasSub = this.rutasService.obtenerRutas().subscribe({
         next: rutas => {
           if (rutas.length === 0) {
             this.router.navigate(['/crear']);
@@ -52,5 +55,9 @@ export class LoginComponent {
     } else {
       this.errorMessage = 'Usuario o contraseña incorrectos';
     }
+  }
+
+  ngOnDestroy(): void {
+    this.rutasSub?.unsubscribe();
   }
 }


### PR DESCRIPTION
## Summary
- manage subscription to `RutasService.obtenerRutas` in login and list views
- implement `OnDestroy` cleanup for these subscriptions

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684088828dd48325bc2d403c1c940069