### PR TITLE
Route created in map component

### DIFF
--- a/src/app/pages/crear-ruta/crear-ruta.component.ts
+++ b/src/app/pages/crear-ruta/crear-ruta.component.ts
@@ -17,7 +17,6 @@ import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { RutasService } from '../../services/rutas.service';
-import { Ruta } from '../../models/ruta';
 
 @Component({
   standalone: true,
@@ -68,12 +67,7 @@ export class CrearRutaComponent {
     if (this.form.valid) {
       const datosRuta = this.form.value;
       localStorage.setItem('rutaTemporal', JSON.stringify(datosRuta));
-      this.rutasService.agregarRuta({
-        ...datosRuta,
-        puntos: []
-      } as Ruta).then(() => {
-        this.router.navigate(['/mapa']);
-      });
+      this.router.navigate(['/mapa']);
     }
   }
 }


### PR DESCRIPTION
## Summary
- remove service route creation from continuar() so it only saves data and navigates
- keep route persistence in `guardarRuta()` on the map component

## Testing
- `npm test` *(fails: ng not found)*
- `npx tsc -p tsconfig.app.json` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_6840a2f40b54832599491bc8cd274bde