### PR TITLE
Add offline navigation support

### DIFF
--- a/public/navega/index.html
+++ b/public/navega/index.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="es">
+<head>
+  <meta charset="utf-8">
+  <title>Navega Offline</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="manifest" href="manifest.json">
+  <style>
+    body { font-family: Arial, sans-serif; margin: 0; padding: 1rem; }
+  </style>
+</head>
+<body>
+  <h1>Navega Ruta</h1>
+  <div id="contenido">Cargando...</div>
+  <script>
+    const cont = document.getElementById('contenido');
+    const id = new URLSearchParams(location.search).get('id');
+    const data = localStorage.getItem('ruta-' + id);
+    if (data) {
+      const ruta = JSON.parse(data);
+      cont.textContent = 'Ruta: ' + ruta.nombre;
+    } else {
+      cont.textContent = 'No hay datos de la ruta';
+    }
+  </script>
+</body>
+</html>

--- a/public/navega/manifest.json
+++ b/public/navega/manifest.json
@@ -1,0 +1,9 @@
+{
+  "name": "Navegar Ruta",
+  "short_name": "Navega",
+  "start_url": "./index.html",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#1976d2",
+  "icons": []
+}

--- a/src/app/pages/navegar-ruta/navegar-ruta.component.html
+++ b/src/app/pages/navegar-ruta/navegar-ruta.component.html
@@ -1,3 +1,29 @@
-<google-map height="100vh" width="100%" [center]="mapaCentro" [zoom]="zoom">
+<div *ngIf="rutaNoExiste" class="ruta-no-existe">
+  Ruta inexistente, consulta con tu Scouter
+</div>
+<div *ngIf="!rutaNoExiste">
+  <div class="ruta-header" *ngIf="ruta">
+    <h1>{{ ruta.nombre }}</h1>
+    <p class="texto-muted">{{ ruta['fechaInicio'] }} {{ ruta['horaInicio'] }} → {{ ruta['fechaFin'] }} {{ ruta['horaFin'] }}</p>
+    <p class="texto-muted">Distancia estimada: {{ ruta['distanciaTotal']?.toFixed(2) }} km</p>
+    <h2>Scouts de México</h2>
+    <hr>
+  </div>
+
+  <div *ngIf="eventoEstado === 'no-iniciado'" class="contador">
+    Comienza en {{ cuentaRegresiva }}
+  </div>
+  <div *ngIf="eventoEstado === 'finalizado'" class="contador">
+    EL evento ha concluido
+  </div>
+  <div *ngIf="eventoEstado === 'en-curso'" class="instrucciones">
+    <ng-container [ngSwitch]="navegador">
+      <p *ngSwitchCase="'chrome'">Agrega esta página a tu inicio desde el menú ⋮ y elige "Agregar a pantalla principal".</p>
+      <p *ngSwitchCase="'safari'">Presiona el botón "Compartir" y selecciona "Agregar a inicio".</p>
+    </ng-container>
+  </div>
+
+  <google-map height="100vh" width="100%" [center]="mapaCentro" [zoom]="zoom">
     <map-polyline [path]="polylinePath" [options]="{ strokeColor: '#1976d2', strokeWeight: 4 }"></map-polyline>
-</google-map>
+  </google-map>
+</div>

--- a/src/app/pages/navegar-ruta/navegar-ruta.component.scss
+++ b/src/app/pages/navegar-ruta/navegar-ruta.component.scss
@@ -1,0 +1,17 @@
+.ruta-header {
+  padding: 1rem;
+  text-align: center;
+}
+
+.texto-muted {
+  color: #666;
+  margin: 0.25rem 0;
+}
+
+.contador,
+.instrucciones,
+.ruta-no-existe {
+  text-align: center;
+  padding: 0.5rem 1rem;
+  font-weight: bold;
+}

--- a/src/app/pages/navegar-ruta/navegar-ruta.component.ts
+++ b/src/app/pages/navegar-ruta/navegar-ruta.component.ts
@@ -1,8 +1,9 @@
-import { Component } from '@angular/core';
+import { Component, OnDestroy } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { CommonModule } from '@angular/common';
 import { GoogleMapsModule } from '@angular/google-maps';
 import { RutasService } from '../../services/rutas.service';
+import { Ruta } from '../../models/ruta';
 
 interface PuntoRuta {
   nombre: string;
@@ -17,18 +18,30 @@ interface PuntoRuta {
   templateUrl: './navegar-ruta.component.html',
   styleUrls: ['./navegar-ruta.component.scss']
 })
-export class NavegarRutaComponent {
+export class NavegarRutaComponent implements OnDestroy {
   puntos: PuntoRuta[] = [];
   mapaCentro = { lat: 20.6205, lng: -100.4483 };
   zoom = 15;
   idRuta: string = '';
+  ruta: Ruta | null = null;
+  rutaNoExiste = false;
+  eventoEstado: 'no-iniciado' | 'en-curso' | 'finalizado' | null = null;
+  cuentaRegresiva = '';
+  navegador: 'chrome' | 'safari' | 'otro' = 'otro';
+  private timer?: ReturnType<typeof setInterval>;
 
   constructor(private route: ActivatedRoute, private rutasService: RutasService) {
+    this.detectarNavegador();
     this.route.paramMap.subscribe(params => {
       this.idRuta = params.get('id') || '';
       if (this.idRuta) {
         this.rutasService.obtenerRutaPorId(this.idRuta).subscribe(ruta => {
-          if (ruta?.puntos) {
+          if (!ruta) {
+            this.rutaNoExiste = true;
+            return;
+          }
+          this.ruta = ruta;
+          if (ruta.puntos) {
             this.puntos = ruta.puntos as PuntoRuta[];
             if (this.puntos.length) {
               this.mapaCentro = {
@@ -37,7 +50,13 @@ export class NavegarRutaComponent {
               };
             }
           }
+          this.actualizarEstadoEvento();
+          if (this.isStandalone()) {
+            this.guardarEnLocalStorage();
+          }
         });
+      } else {
+        this.rutaNoExiste = true;
       }
     });
 
@@ -55,4 +74,72 @@ export class NavegarRutaComponent {
   get polylinePath() {
     return this.puntos.map(p => ({ lat: p.lat, lng: p.lng }));
   }
+
+  private detectarNavegador() {
+    const ua = navigator.userAgent;
+    if (/Chrome/i.test(ua)) {
+      this.navegador = 'chrome';
+    } else if (/Safari/i.test(ua)) {
+      this.navegador = 'safari';
+    }
+  }
+
+  private actualizarEstadoEvento() {
+    if (!this.ruta) {
+      return;
+    }
+    const inicio = new Date(`${this.ruta.fechaInicio}T${this.ruta.horaInicio}`);
+    const fin = new Date(`${this.ruta.fechaFin}T${this.ruta.horaFin}`);
+    const ahora = new Date();
+
+    if (ahora < inicio) {
+      this.eventoEstado = 'no-iniciado';
+      this.iniciarCuentaRegresiva(inicio);
+    } else if (ahora > fin) {
+      this.eventoEstado = 'finalizado';
+    } else {
+      this.eventoEstado = 'en-curso';
+    }
+  }
+
+  private iniciarCuentaRegresiva(fecha: Date) {
+    this.actualizarCuentaRegresiva(fecha);
+    this.timer = setInterval(() => this.actualizarCuentaRegresiva(fecha), 1000);
+  }
+
+  private actualizarCuentaRegresiva(fecha: Date) {
+    const diff = fecha.getTime() - Date.now();
+    if (diff <= 0) {
+      this.cuentaRegresiva = '00:00:00';
+      if (this.timer) {
+        clearInterval(this.timer);
+      }
+      this.actualizarEstadoEvento();
+      return;
+    }
+    const h = Math.floor(diff / 3600000);
+    const m = Math.floor((diff % 3600000) / 60000);
+    const s = Math.floor((diff % 60000) / 1000);
+    this.cuentaRegresiva = [h, m, s]
+      .map(v => v.toString().padStart(2, '0'))
+      .join(':');
+  }
+
+  private isStandalone(): boolean {
+    return window.matchMedia('(display-mode: standalone)').matches ||
+      (navigator as any).standalone;
+  }
+
+  private guardarEnLocalStorage() {
+    if (this.ruta) {
+      localStorage.setItem(`ruta-${this.idRuta}`, JSON.stringify(this.ruta));
+    }
+  }
+
+  ngOnDestroy(): void {
+    if (this.timer) {
+      clearInterval(this.timer);
+    }
+  }
 }
+


### PR DESCRIPTION
## Summary
- update mobile navigation screen with header and countdown handling
- detect browsers and save route locally when launched from a PWA
- show proper messaging when route isn't found
- style navigation page for mobile use
- add static offline page under `/navega` with a minimal manifest

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840a8acd8748325bae67258768391aa