### PR TITLE
Improve routes ordering and PWA nav logic

### DIFF
--- a/public/navega/index.html
+++ b/public/navega/index.html
@@ -16,7 +16,10 @@
     const cont = document.getElementById('contenido');
     const id = new URLSearchParams(location.search).get('id');
     const data = localStorage.getItem('ruta-' + id);
-    if (data) {
+    const instalada = window.matchMedia('(display-mode: standalone)').matches || navigator.standalone;
+    if (!instalada) {
+      cont.textContent = 'Agrega esta página a tu inicio para navegar sin conexión.';
+    } else if (data) {
       const ruta = JSON.parse(data);
       cont.textContent = 'Ruta: ' + ruta.nombre;
     } else {

--- a/src/app/pages/lista-rutas/lista-rutas.component.html
+++ b/src/app/pages/lista-rutas/lista-rutas.component.html
@@ -1,5 +1,6 @@
 <div class="rutas-container">
   <h2>Rutas guardadas</h2>
+  <button mat-raised-button color="primary" (click)="crearRuta()">Nueva ruta</button>
 
   <div *ngIf="rutas.length === 0" class="mensaje-vacio">
     Aún no has creado rutas. Ve a "Crear Ruta" para empezar una aventura.

--- a/src/app/pages/lista-rutas/lista-rutas.component.ts
+++ b/src/app/pages/lista-rutas/lista-rutas.component.ts
@@ -46,7 +46,13 @@ export class ListaRutasComponent implements OnInit, OnDestroy {
   ngOnInit(): void {
     this.rutasSub = this.rutasService.obtenerRutas().subscribe({
       next: (rutas) => {
-        this.rutas = rutas.map(r => ({ ...r, mostrarQR: false, mostrarDetalle: false }));
+        this.rutas = rutas
+          .sort((a, b) => {
+            const fechaA = new Date(a.fechaCreacion).getTime();
+            const fechaB = new Date(b.fechaCreacion).getTime();
+            return fechaB - fechaA;
+          })
+          .map(r => ({ ...r, mostrarQR: false, mostrarDetalle: false }));
       },
       error: (err) => {
         console.error('Error al obtener rutas:', err);

--- a/src/app/pages/navegar-ruta/navegar-ruta.component.html
+++ b/src/app/pages/navegar-ruta/navegar-ruta.component.html
@@ -16,14 +16,14 @@
   <div *ngIf="eventoEstado === 'finalizado'" class="contador">
     EL evento ha concluido
   </div>
-  <div *ngIf="eventoEstado === 'en-curso'" class="instrucciones">
+  <div *ngIf="eventoEstado === 'en-curso' && !instalada" class="instrucciones">
     <ng-container [ngSwitch]="navegador">
       <p *ngSwitchCase="'chrome'">Agrega esta página a tu inicio desde el menú ⋮ y elige "Agregar a pantalla principal".</p>
       <p *ngSwitchCase="'safari'">Presiona el botón "Compartir" y selecciona "Agregar a inicio".</p>
     </ng-container>
   </div>
 
-  <google-map height="100vh" width="100%" [center]="mapaCentro" [zoom]="zoom">
+  <google-map *ngIf="instalada" height="100vh" width="100%" [center]="mapaCentro" [zoom]="zoom">
     <map-polyline [path]="polylinePath" [options]="{ strokeColor: '#1976d2', strokeWeight: 4 }"></map-polyline>
   </google-map>
 </div>

--- a/src/app/pages/navegar-ruta/navegar-ruta.component.ts
+++ b/src/app/pages/navegar-ruta/navegar-ruta.component.ts
@@ -28,10 +28,12 @@ export class NavegarRutaComponent implements OnDestroy {
   eventoEstado: 'no-iniciado' | 'en-curso' | 'finalizado' | null = null;
   cuentaRegresiva = '';
   navegador: 'chrome' | 'safari' | 'otro' = 'otro';
+  instalada = false;
   private timer?: ReturnType<typeof setInterval>;
 
   constructor(private route: ActivatedRoute, private rutasService: RutasService) {
     this.detectarNavegador();
+    this.instalada = this.isStandalone();
     this.route.paramMap.subscribe(params => {
       this.idRuta = params.get('id') || '';
       if (this.idRuta) {
@@ -51,7 +53,7 @@ export class NavegarRutaComponent implements OnDestroy {
             }
           }
           this.actualizarEstadoEvento();
-          if (this.isStandalone()) {
+          if (this.instalada) {
             this.guardarEnLocalStorage();
           }
         });


### PR DESCRIPTION
## Summary
- show latest routes first
- add button to create a new route
- hide install instructions once PWA installed
- show install instructions in offline `navega` page when not installed

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840afa7fc1483258fb3c5dac417a9db